### PR TITLE
update to work with newer colorbuddy

### DIFF
--- a/lua/monokai-soda.lua
+++ b/lua/monokai-soda.lua
@@ -1,4 +1,9 @@
-local Color, colors, Group, groups, styles = require('colorbuddy').setup()
+local colorbuddy = require("colorbuddy")
+local Color = colorbuddy.Color
+local Group = colorbuddy.Group
+local colors = colorbuddy.colors
+local groups = colorbuddy.groups
+local styles = colorbuddy.styles
 
 vim.g.colors_name = 'monokai-soda'
 vim.cmd('set background=dark')


### PR DESCRIPTION
It looks like colorbuddy made the setup() method a no-op. The current README has all names being aliased individually.

https://github.com/tjdevries/colorbuddy.nvim/commit/40b17320d27571b21ab4caf423c53edeb3c7a5eb#diff-49a7023038ce2b017886c748f9f7ab1e8c30ab29c358d1d8eb382053258dd2e7L29-R18